### PR TITLE
mentions QtCreator support for Catch2 in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Code::Blocks                      | ?      | ?      | ?      | ?      | &nbsp;|
 CodeLite                          | ?      | ?      | ?      | ?      | &nbsp;|
 Eclipse CDT                       | ?      | ?      | ?      | ?      | &nbsp;|
 KDevelop                          | ?      | ?      | ?      | ?      | &nbsp;|
-Qt Creator                        | ?      | ?      | ?      | ?      | &nbsp;|
+Qt Creator                        | ?      | ?      | &#10003;| ?      | &nbsp;|
 Visual-MinGW                      | ?      | ?      | ?      | ?      | &nbsp;|
 Visual Studio                     | &bull; | &bull; | &bull; | -      | Catch and doctest: via ReSharper C++ |
 Visual Studio Code                | -      | -      | -      | -      | see [issue](https://github.com/Microsoft/vscode-cpptools/issues/1079)|


### PR DESCRIPTION
not tested, but Catch2 is listed in the QtCreator docs: https://doc-snapshots.qt.io/qtcreator-master/creator-autotest.html